### PR TITLE
fix: parser stack overflow and parser dropping errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +540,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +577,7 @@ dependencies = [
  "insta",
  "logos",
  "serde",
+ "stacker",
  "thiserror",
 ]
 

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -10,4 +10,5 @@ indexmap = { version = "1.9.1", features = ["serde"] }
 insta = "1.21.0"
 logos = "0.12.1"
 serde = { version = "1.0.147", features = ["derive"] }
+stacker = "0.1.15"
 thiserror = "1.0.37"

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -1052,13 +1052,14 @@ impl<'a> Parser<'a> {
 
 // On average, a single parse_XXX() method consumes between 10 and 700 bytes of
 // stack space. Assuming ~50 recursive calls per dive and 700 bytes of stack
-// space per call, we'll require 50 * 700 = 35,000 bytes of stack space in order
-// to dive. We may want to tune this value.
-const RECURSION_CHAIN_DEPTH: usize = 50;
-const PESSIMISTIC_STACKFRAME_SIZE: usize = 700;
-const MINIMUM_STACK_REQUIRED: usize = RECURSION_CHAIN_DEPTH * PESSIMISTIC_STACKFRAME_SIZE;
+// space per call, we'll require 50 * 700 = 35k bytes of stack space in order
+// to dive. For future proofing, we round this value up to 64k bytes.
+const MINIMUM_STACK_REQUIRED: usize = 64_000;
 
-// On WASM, remaining_stack() will always return None.
+// On WASM, remaining_stack() will always return None. Stack overflow panics
+// are converted to exceptions and handled by the host, which means a
+// `try { ... } catch { ... }` around a call to one of the Mu compiler functions
+// would be enough.
 #[cfg(target_family = "wasm")]
 fn check_recursion_limit(_span: Span) -> Result<(), Error> {
   Ok(())

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -23,6 +23,14 @@ use crate::span::{Span, Spanned};
 #[macro_use]
 mod macros;
 
+// On average, a single parse_XXX() method consumes between 10 and 700 bytes of
+// stack space. Assuming ~50 recursive calls per dive and 700 bytes of stack
+// space per call, we'll require 50 * 700 = 35,000 bytes of stack space in order
+// to dive. We may want to tune this value.
+const RECURSION_CHAIN_DEPTH: usize = 50;
+const PESSIMISTIC_STACKFRAME_SIZE: usize = 700;
+const MINIMUM_STACK_REQUIRED: usize = RECURSION_CHAIN_DEPTH * PESSIMISTIC_STACKFRAME_SIZE;
+
 // https://github.com/ves-lang/ves/blob/master/ves-parser/src/parser.rs
 
 pub fn parse(source: &str) -> Result<Module<'_>, Vec<Error>> {
@@ -176,7 +184,14 @@ impl<'a> Parser<'a> {
       // if true { "a" } else { "b" } // not required
       // "b" // required
       if !self.previous().is(BraceR) {
-        self.expect(Semicolon)?;
+        let semi = self.expect(Semicolon);
+        if let Err(e) = semi {
+          // Preserve the original error
+          if let Err(stmt_error) = stmt {
+            self.errors.push(stmt_error);
+          }
+          return Err(e);
+        }
       } else {
         self.bump_if(Semicolon);
       }
@@ -508,6 +523,7 @@ impl<'a> Parser<'a> {
       Float, Ident, If, Int, Lambda, Null, ParenL, ParenR, Return, Semicolon, Spawn, String, Throw,
       Try,
     };
+    Self::check_recursion_limit(self.current().span)?;
 
     // expr_null
     if self.bump_if(Null) {
@@ -737,6 +753,7 @@ impl<'a> Parser<'a> {
   // `"{" (stmt ";")* expr? "}"
   fn parse_block(&mut self) -> Result<Block<'a>, Error> {
     use TokenKind::{BraceL, BraceR, For, Let, Loop, Semicolon, While};
+    Self::check_recursion_limit(self.current().span)?;
 
     let mut block = Block {
       items: vec![],
@@ -774,6 +791,7 @@ impl<'a> Parser<'a> {
   }
 
   fn parse_type(&mut self) -> Result<TypeKind<'a>, Error> {
+    Self::check_recursion_limit(self.current().span)?;
     self.parse_type_option()
   }
 
@@ -1045,6 +1063,33 @@ impl<'a> Parser<'a> {
     std::mem::swap(&mut self.ctx, &mut prev_ctx);
     res
   }
+
+  // On WASM, remaining_stack() will always return None.
+  #[cfg(target_family = "wasm")]
+  fn check_recursion_limit(_span: Span) -> Result<(), Error> {
+    Ok(())
+  }
+
+  #[cfg(not(target_family = "wasm"))]
+  fn check_recursion_limit(span: Span) -> Result<(), Error> {
+    // On the platforms we're targeting (linux, windows, osx), remaining_stack()
+    // should always return Some, so we'll able to bail out if an overflow is
+    // likely. On all other platforms, we'll continue parsing, but warn the user
+    // at compile time.
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+      const WARNING: &str = "The detect platform is neither linux, windows, macos, or wasm, which means that the parser can cause a stack overflow. Use with care.";
+    }
+
+    if stacker::remaining_stack()
+      .map(|available| available > MINIMUM_STACK_REQUIRED)
+      .unwrap_or(true)
+    {
+      Ok(())
+    } else {
+      Err(Error::NestingLimitReached(span))
+    }
+  }
 }
 
 // Adapted from https://docs.rs/snailquote/0.3.0/x86_64-pc-windows-msvc/src/snailquote/lib.rs.html.
@@ -1209,6 +1254,8 @@ pub enum Error {
   // NOTE: temporary error to avoid false-positives while fuzzing.
   #[error("parsing {0} is not yet implemented")]
   NotImplemented(&'static str),
+  #[error("the maximum amount of nesting has been reached")]
+  NestingLimitReached(Span),
 }
 
 impl Error {

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -1073,7 +1073,7 @@ fn check_recursion_limit(span: Span) -> Result<(), Error> {
   // at compile time.
   #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
   {
-    const WARNING: &str = "The detect platform is neither linux, windows, macos, or wasm, which means that the parser can cause a stack overflow. Use with care.";
+    const WARNING: &str = "The detected platform is neither Linux, Windows, MacOS, or WASM, which means that the parser may panic on stack overflow. Use with care.";
   }
 
   if stacker::remaining_stack()

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -178,24 +178,17 @@ impl<'a> Parser<'a> {
       self.expect(Semicolon)?;
       stmt
     } else {
-      let stmt = self.parse_stmt_expr();
+      let stmt = self.parse_stmt_expr()?;
       // semicolon after expr stmt is only required if the expr does not end with `}`,
       // for example:
       // if true { "a" } else { "b" } // not required
       // "b" // required
       if !self.previous().is(BraceR) {
-        let semi = self.expect(Semicolon);
-        if let Err(e) = semi {
-          // Preserve the original error
-          if let Err(stmt_error) = stmt {
-            self.errors.push(stmt_error);
-          }
-          return Err(e);
-        }
+        self.expect(Semicolon)?;
       } else {
         self.bump_if(Semicolon);
       }
-      stmt
+      Ok(stmt)
     }
   }
 

--- a/fuzz/libfuzzer/Cargo.lock
+++ b/fuzz/libfuzzer/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +244,7 @@ dependencies = [
  "insta",
  "logos",
  "serde",
+ "stacker",
  "thiserror",
 ]
 

--- a/fuzz/mu-fuzz-cli/src/reproduce.rs
+++ b/fuzz/mu-fuzz-cli/src/reproduce.rs
@@ -1,5 +1,5 @@
 use syntax::lexer::Lexer;
-use syntax::parser::parse;
+use syntax::parser::{parse, Error};
 
 pub fn lexer(input: &str) {
   let tokens = Lexer::new(input).into_iter().collect::<Vec<_>>();
@@ -21,8 +21,12 @@ pub fn parser(input: &str) {
       println!("[REPRO] Gracefully parsed the input module.")
     }
     Err(errors) => {
+      let errors = errors
+        .into_iter()
+        .filter(|e| !matches!(e, Error::Lexer(_, _)))
+        .collect::<Vec<_>>();
       println!(
-        "[REPRO] Gracefully parsed the input module with errors:\n{:#?}",
+        "[REPRO] Gracefully parsed the input module with errors (lexer errors filtered out):\n{:#?}",
         errors
       );
     }

--- a/justfile
+++ b/justfile
@@ -10,4 +10,4 @@ set windows-shell := ["pwsh.exe", "-NoLogo", "-Command"]
 
 # Print the available fuzz targets and backends.
 @fuzz-targets:
-  RUST_BACKTRACE=1 cargo run --quiet --bin mu-fuzz-cli info --list-backends --list-targets
+  cargo run --quiet --bin mu-fuzz-cli info --list-backends --list-targets


### PR DESCRIPTION
I've fuzzed the parser for an hour and it seems to be crash-free as of now. Also, we may want to decrease the minimum stack size limit in release builds. The one I have there right now eliminates stack overlow in debug builds as well.

* fix: stackoverflow in the parser
* fix: parser dropping errors while parsing expression statements if there's no semicolon 